### PR TITLE
Include package type in error messages

### DIFF
--- a/lib/papers/dependency_specification/bower_component.rb
+++ b/lib/papers/dependency_specification/bower_component.rb
@@ -38,6 +38,10 @@ module Papers
       end
     end
 
+    def self.asset_type_name
+      'Bower component'
+    end
+
     def self.manifest_key
       "bower_components"
     end

--- a/lib/papers/dependency_specification/gem.rb
+++ b/lib/papers/dependency_specification/gem.rb
@@ -22,6 +22,10 @@ module Papers
       end
     end
 
+    def self.asset_type_name
+      'Gem'
+    end
+
     def self.manifest_key
       "gems"
     end

--- a/lib/papers/dependency_specification/javascript.rb
+++ b/lib/papers/dependency_specification/javascript.rb
@@ -22,6 +22,10 @@ module Papers
       files.compact
     end
 
+    def self.asset_type_name
+      'JavaScript file'
+    end
+
     def self.manifest_key
       "javascripts"
     end

--- a/lib/papers/dependency_specification/npm_package.rb
+++ b/lib/papers/dependency_specification/npm_package.rb
@@ -26,6 +26,10 @@ module Papers
       }
     end
 
+    def self.asset_type_name
+      'npm package'
+    end
+
     def self.manifest_key
       "npm_packages"
     end

--- a/lib/papers/license_validator.rb
+++ b/lib/papers/license_validator.rb
@@ -20,7 +20,7 @@ module Papers
       validate_spec_type(Gem)            if Papers.config.validate_gems?
       validate_spec_type(Javascript)     if Papers.config.validate_javascript?
       validate_spec_type(BowerComponent) if Papers.config.validate_bower_components?
-      validate_spec_type(NpmPackage)  if Papers.config.validate_npm_packages?
+      validate_spec_type(NpmPackage)     if Papers.config.validate_npm_packages?
 
       @errors.empty?
     end
@@ -48,17 +48,18 @@ module Papers
     private
 
       def validate_spec_type(spec_type)
+        asset_type_name = spec_type.asset_type_name
         spec_type.missing_from_manifest(manifest).each do |name|
-          errors << "#{name} is included in the application, but not in the manifest"
+          errors << "#{asset_type_name} #{name} is included in the application, but not in the manifest"
         end
 
         spec_type.unknown_in_manifest(manifest).each do |name|
-          errors << "#{name} is included in the manifest, but not in the application"
+          errors << "#{asset_type_name} #{name} is included in the manifest, but not in the application"
         end
 
         spec_type.all_from_manifest(manifest).each do |spec|
           unless spec.acceptable_license?
-            errors << "#{spec.name} is licensed under #{spec.license}, which is not whitelisted"
+            errors << "#{asset_type_name} #{spec.name} is licensed under #{spec.license}, which is not whitelisted"
           end
         end
       end

--- a/spec/papers_spec.rb
+++ b/spec/papers_spec.rb
@@ -33,8 +33,8 @@ describe 'Papers' do
     expect(validator.valid?).to be_falsey
 
     expect(validator.errors).to eq([
-      'bar-1.2 is included in the application, but not in the manifest',
-      'foo-1.2 is included in the manifest, but not in the application'
+      'Gem bar-1.2 is included in the application, but not in the manifest',
+      'Gem foo-1.2 is included in the manifest, but not in the application'
     ])
 
     validator.valid?
@@ -57,8 +57,8 @@ describe 'Papers' do
     expect(validator.valid?).to be_falsey
 
     expect(validator.errors).to eq([
-      'baz-1.2 is included in the application, but not in the manifest',
-      'baz-1.3 is included in the manifest, but not in the application'
+      'Gem baz-1.2 is included in the application, but not in the manifest',
+      'Gem baz-1.3 is included in the manifest, but not in the application'
     ])
     validator.valid?
   end
@@ -80,8 +80,8 @@ describe 'Papers' do
     expect(validator).not_to be_valid
 
     expect(validator.errors).to eq([
-      'foo-1.2 is included in the application, but not in the manifest',
-      'foo is included in the manifest, but not in the application'
+      'Gem foo-1.2 is included in the application, but not in the manifest',
+      'Gem foo is included in the manifest, but not in the application'
     ])
     validator.valid?
   end
@@ -118,8 +118,8 @@ describe 'Papers' do
 
     expect(validator).not_to be_valid
     expect(validator.errors).to eq([
-      'baz-1.2 is included in the application, but not in the manifest',
-      'baz is included in the manifest, but not in the application'
+      'Gem baz-1.2 is included in the application, but not in the manifest',
+      'Gem baz is included in the manifest, but not in the application'
     ])
   end
 
@@ -139,7 +139,7 @@ describe 'Papers' do
     expect(validator).not_to be_valid
 
     expect(validator.errors).to eq([
-      'baz-1.3 is licensed under GPL, which is not whitelisted'
+      'Gem baz-1.3 is licensed under GPL, which is not whitelisted'
     ])
   end
 


### PR DESCRIPTION
When changing deps over from Bower to npm packages, the error messages of what's included in the manifest but not application (and vice-versa) get confusing. This helps that!
