### PR TITLE
Add a flag to ignore npm dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.0
+* Add `config.ignore_npm_dev_dependencies` option to not apply validation to npm devDepdency modules. This is useful if you don't need to consider packages that aren't use in production.
+
 ## 2.2.0
 
 * Fix empty npm package name bug. The name of an npm package would be blank when its version was,

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Papers.configure do |config|
   # Configures Papers to validate licenses for NPM dependencies. Defaults to false.
   config.validate_npm_packages = false
 
+  # Configured Papers to ignore NPM dev dependencies. Defaults to false.
+  config.ignore_npm_dev_dependencies = false
+
   # Configures where Papers should look for the package.json file. Defaults to:
   # package.json in the root directory of the project
   config.npm_package_json_path = File.join(Dir.pwd, 'package.json')

--- a/lib/papers/configuration.rb
+++ b/lib/papers/configuration.rb
@@ -9,6 +9,7 @@ module Papers
     attr_accessor :validate_javascript
     attr_accessor :validate_bower_components
     attr_accessor :validate_npm_packages
+    attr_accessor :ignore_npm_dev_dependencies
 
     attr_accessor :javascript_paths
     attr_accessor :whitelist_javascript_paths
@@ -37,7 +38,7 @@ module Papers
       @validate_javascript       = true
       @validate_bower_components = false
       @validate_npm_packages = false
-
+      @ignore_npm_dev_dependencies = false
 
       @javascript_paths = [
         File.join(Dir.pwd, 'app',    'assets', 'javascripts'),
@@ -65,6 +66,10 @@ module Papers
 
     def validate_npm_packages?
       !!@validate_npm_packages
+    end
+
+    def ignore_npm_dev_dependencies?
+      !!@ignore_npm_dev_dependencies
     end
 
   end

--- a/lib/papers/dependency_specification/npm_package.rb
+++ b/lib/papers/dependency_specification/npm_package.rb
@@ -7,7 +7,8 @@ module Papers
     end
 
     def self.full_introspected_entries
-      packages = (package['dependencies'] || {}).merge((package['devDependencies'] || {}))
+      packages = (package['dependencies'] || {})
+      packages.merge!((package['devDependencies'] || {})) unless Papers.config.ignore_npm_dev_dependencies
       packages.map do |name, version|
         # FIXME: This version cleanup is inadequate for npm version specifiers, which may be git or
         # tarball URLs.

--- a/lib/papers/version.rb
+++ b/lib/papers/version.rb
@@ -1,7 +1,7 @@
 module Papers
   class Version
     MAJOR = 2
-    MINOR = 2
+    MINOR = 3
     PATCH = 0
 
     def self.to_s

--- a/spec/npm_package_spec.rb
+++ b/spec/npm_package_spec.rb
@@ -22,16 +22,25 @@ describe 'NpmPackageSpecification' do
       expect { Papers::NpmPackage.full_introspected_entries }.to raise_error JSON::ParserError
     end
 
-    it 'combines dependencies and devDependencies' do
+    it 'combines dependencies and devDependencies by default' do
       allow(Papers::NpmPackage).to receive(:package).and_return({
         'dependencies'    => { 'prod_package' => '~> 1.2.3' },
         'devDependencies' => {'dev_package' => '~> 1.2.0'}
       })
-
-
       expect(Papers::NpmPackage.full_introspected_entries).to eq([
         { 'name' => 'prod_package', 'version' => '1.2.3' },
         { 'name' => 'dev_package', 'version' => '1.2.0' }
+      ])
+    end
+
+    it 'does not combine dependencies and devDependencies when ignore_npm_dev_dependencies is true' do
+      allow(Papers::NpmPackage).to receive(:package).and_return({
+        'dependencies'    => { 'prod_package' => '~> 1.2.3' },
+        'devDependencies' => {'dev_package' => '~> 1.2.0'}
+      })
+      allow_any_instance_of(Papers::Configuration).to receive(:ignore_npm_dev_dependencies).and_return(true)
+      expect(Papers::NpmPackage.full_introspected_entries).to eq([
+        { 'name' => 'prod_package', 'version' => '1.2.3' }
       ])
     end
 


### PR DESCRIPTION
Makes the consideration of dev dependencies from npm packages configurable. Default behavior is unchanged, but setting ignore_npm_dev_dependencies to true will ignore the dev dependencies.

sidekick: @idleyoungman 
cc: @tedpennings
