### PR TITLE
Fix help output

### DIFF
--- a/lib/papers/cli.rb
+++ b/lib/papers/cli.rb
@@ -19,22 +19,18 @@ module Papers
 
     def parse_options
       options = {}
-      opts = OptionParser.new do |opts|
-        opts.banner = "Usage: papers [options]"
+      OptionParser.new do |opts|
+        opts.banner = 'Usage: papers [options]'
 
-        opts.on("-g", "--generate", "Generate papers_manifest.yml") do |v|
+        opts.on('-g', '--generate', 'Generate papers_manifest.yml') do |v|
           options[:generate] = v
         end
 
-        opts.on_tail( '-h', '--help', 'Display this screen' ) do |v|
-          p opts.to_s
-          return {}
+        opts.on_tail('-h', '--help', 'Display this screen') do
+          puts opts
         end
       end.parse!
-
-      p opts.to_s if options.empty?
-
-      return options
+      options
     end
   end
 end

--- a/lib/papers/cli.rb
+++ b/lib/papers/cli.rb
@@ -19,7 +19,7 @@ module Papers
 
     def parse_options
       options = {}
-      OptionParser.new do |opts|
+      opts = OptionParser.new do |opts|
         opts.banner = "Usage: papers [options]"
 
         opts.on("-g", "--generate", "Generate papers_manifest.yml") do |v|
@@ -27,13 +27,12 @@ module Papers
         end
 
         opts.on_tail( '-h', '--help', 'Display this screen' ) do |v|
-          p opts
-          exit
+          p opts.to_s
+          return {}
         end
-        @avail_opts = opts
       end.parse!
 
-      p @avail_opts if options.empty?
+      p opts.to_s if options.empty?
 
       return options
     end

--- a/spec/papers_spec.rb
+++ b/spec/papers_spec.rb
@@ -416,21 +416,28 @@ describe 'Papers' do
   end
 
   describe "Command Line" do
+    def silently
+      vblevel = $VERBOSE 
+      $VERBOSE = nil
+      yield
+    ensure
+      $VERBOSE = vblevel
+    end
+    
     before do
       @old_argv = ARGV
     end
     after do
-      ARGV = @old_argv
+      silently { ARGV = @old_argv }
     end
-  end
-  it "runs the papers command and prints out help" do
-
-    ARGV = %w[-h]
-    cli = Papers::CLI.new
-    expect(cli).to receive(:puts) do |opts|
-      expect(opts.to_s).to match /^Usage: papers.*/
+    it "runs the papers command and prints out help" do
+      silently { ARGV = %w[-h] }
+      cli = Papers::CLI.new
+      expect(cli).to receive(:puts) do |opts|
+        expect(opts.to_s).to match /^Usage: papers.*/
+      end
+      cli.run
     end
-    cli.run
   end
 
 

--- a/spec/papers_spec.rb
+++ b/spec/papers_spec.rb
@@ -427,9 +427,10 @@ describe 'Papers' do
 
     ARGV = %w[-h]
     cli = Papers::CLI.new
-    expect(cli).to receive(:p).with(/^Usage: .*/)
+    expect(cli).to receive(:puts) do |opts|
+      expect(opts.to_s).to match /^Usage: papers.*/
+    end
     cli.run
-
   end
 
 

--- a/spec/papers_spec.rb
+++ b/spec/papers_spec.rb
@@ -415,5 +415,22 @@ describe 'Papers' do
     expect(validator).to be_valid
   end
 
+  describe "Command Line" do
+    before do
+      @old_argv = ARGV
+    end
+    after do
+      ARGV = @old_argv
+    end
+  end
+  it "runs the papers command and prints out help" do
+
+    ARGV = %w[-h]
+    cli = Papers::CLI.new
+    expect(cli).to receive(:p).with(/^Usage: .*/)
+    cli.run
+
+  end
+
 
 end


### PR DESCRIPTION
The help output was printing an inspect string on the arguments.  I fixed this, added a test, and also removed the exit since it was unnecessary and messed with the test.

Before, the output looked like this:

``` bash
$ papers -h
#<OptionParser:0x007f89d2a8ca88 @stack=[#<OptionParser::List:0x007f89d48189d0 @atype= ...
```
