### PR TITLE
Support papers --update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
 script: bundle exec rspec
 notifications:
   email:

--- a/lib/papers.rb
+++ b/lib/papers.rb
@@ -1,6 +1,8 @@
 require 'papers/configuration'
 require 'papers/license_validator'
+require 'papers/manifest_command'
 require 'papers/manifest_generator'
+require 'papers/manifest_updater'
 require 'papers/cli'
 require 'papers/version'
 

--- a/lib/papers/cli.rb
+++ b/lib/papers/cli.rb
@@ -7,16 +7,14 @@ module Papers
     def run
       if options[:generate]
         begin
-          generator = Papers::ManifestGenerator.new
-          generator.generate!
+          Papers::ManifestGenerator.new.generate!
         rescue Papers::FileExistsError => e
           warn "Error: 'papers_manifest.yml' already exists at '#{e.message}'. Aborting..."
         end
       end
 
       if options[:update]
-        updater = Papers::ManifestUpdater.new
-        updater.update!
+        Papers::ManifestUpdater.new.update!
       end
     end
 

--- a/lib/papers/cli.rb
+++ b/lib/papers/cli.rb
@@ -5,7 +5,7 @@ module Papers
   class CLI
 
     def run
-      if parse_options[:generate]
+      if options[:generate]
         begin
           generator = Papers::ManifestGenerator.new
           generator.generate!
@@ -13,9 +13,18 @@ module Papers
           warn "Error: 'papers_manifest.yml' already exists at '#{e.message}'. Aborting..."
         end
       end
+
+      if options[:update]
+        updater = Papers::ManifestUpdater.new
+        updater.update!
+      end
     end
 
     private
+
+    def options
+      @options ||= parse_options
+    end
 
     def parse_options
       options = {}
@@ -24,6 +33,10 @@ module Papers
 
         opts.on("-g", "--generate", "Generate papers_manifest.yml") do |v|
           options[:generate] = v
+        end
+
+        opts.on("-u", "--update", "Update papers_manifest.yml for Rubygems") do |v|
+          options[:update] = v
         end
 
         opts.on_tail( '-h', '--help', 'Display this screen' ) do |v|

--- a/lib/papers/manifest_command.rb
+++ b/lib/papers/manifest_command.rb
@@ -17,6 +17,50 @@ module Papers
       ].join("\n")
     end
 
+    def get_installed_gems
+      gems = {}
+      Bundler.load.specs.each do |spec|
+        gems[gem_name_and_version(spec)] = gem_entry(spec)
+      end
+      return gems
+    end
+
+    def get_installed_javascripts
+      js = {}
+      Javascript.introspected.each do |entry|
+        js[entry] = {
+          'license'     => 'Unknown',
+          'license_url' => nil,
+          'project_url' => nil
+        }
+      end
+      js.empty? ? nil : js
+    end
+
+    def get_installed_bower_components
+      components = {}
+      BowerComponent.full_introspected_entries.each do |entry|
+        components[entry['name']] = {
+          'license' => 'Unknown',
+          'license_url' => nil,
+          'project_url' => ensure_valid_url(entry['homepage'])
+        }
+      end
+      components.empty? ? nil : components
+    end
+
+    def get_installed_npm_packages
+      packages = {}
+      NpmPackage.full_introspected_entries.each do |entry|
+        packages[entry['name']] = {
+          'license' => 'Unknown',
+          'license_url' => nil,
+          'project_url' => nil
+        }
+      end
+      packages.empty? ? nil : packages
+    end
+
     def gem_name_and_version(spec)
       if spec.name == 'bundler'
         name_and_version = spec.name

--- a/lib/papers/manifest_command.rb
+++ b/lib/papers/manifest_command.rb
@@ -1,0 +1,53 @@
+module Papers
+  class ManifestCommand
+    def initialize(manifest_path = nil)
+      @manifest_path = manifest_path || File.join('config','papers_manifest.yml')
+    end
+
+    def manifest_exists?
+      !!File.exist?(@manifest_path)
+    end
+
+    def build_header
+      [
+        "# Dependency Manifest for the Papers gem",
+        "# Used to test your gems and javascript against license whitelist",
+        "#",
+        "# http://github.com/newrelic/papers\n"
+      ].join("\n")
+    end
+
+    def gem_name_and_version(spec)
+      if spec.name == 'bundler'
+        name_and_version = spec.name
+      else
+        name_and_version = "#{spec.name}-#{spec.version}"
+      end
+    end
+
+    def gem_entry(spec)
+      gem_license     = blank?(spec.license) ? 'Unknown' : spec.license
+      gem_project_url = blank?(spec.homepage) ? nil : spec.homepage
+
+      {
+        'license'     => gem_license,
+        'license_url' => nil,
+        'project_url' => ensure_valid_url(gem_project_url)
+        # TODO: add support for multiple licenses? some gemspecs have dual licensing
+      }
+    end
+
+    def blank?(str)
+      str.respond_to?(:empty?) ? str.empty? : !str
+    end
+
+    def ensure_valid_url(url_string)
+      match_url = URI::regexp.match(url_string)
+      if match_url.nil?
+        nil
+      else
+        match_url[0]
+      end
+    end
+  end
+end

--- a/lib/papers/manifest_command.rb
+++ b/lib/papers/manifest_command.rb
@@ -1,11 +1,11 @@
 module Papers
   class ManifestCommand
     def initialize(manifest_path = nil)
-      @manifest_path = manifest_path || File.join('config','papers_manifest.yml')
+      @manifest_path = manifest_path || File.join('config', 'papers_manifest.yml')
     end
 
     def manifest_exists?
-      !!File.exist?(@manifest_path)
+      File.exist?(@manifest_path)
     end
 
     def build_header
@@ -82,7 +82,7 @@ module Papers
     end
 
     def blank?(str)
-      str.respond_to?(:empty?) ? str.empty? : !str
+      str.to_s.empty?
     end
 
     def ensure_valid_url(url_string)

--- a/lib/papers/manifest_generator.rb
+++ b/lib/papers/manifest_generator.rb
@@ -4,7 +4,6 @@ require 'fileutils'
 require 'uri'
 
 module Papers
-
   class FileExistsError < StandardError;
     attr_reader :manifest_path
 
@@ -14,11 +13,8 @@ module Papers
     end
   end
 
-  class ManifestGenerator
-
+  class ManifestGenerator < ManifestCommand
     def generate!(args = ARGV)
-      @manifest_path = File.join('config','papers_manifest.yml')
-
       raise Papers::FileExistsError.new(@manifest_path) if manifest_exists?
 
       begin
@@ -49,21 +45,7 @@ module Papers
     def get_installed_gems
       gems = {}
       Bundler.load.specs.each do |spec|
-        if spec.name == 'bundler'
-          name_and_version = spec.name
-        else
-          name_and_version = "#{spec.name}-#{spec.version}"
-        end
-
-        gem_license     = blank?(spec.license) ? 'Unknown' : spec.license
-        gem_project_url = blank?(spec.homepage) ? nil : spec.homepage
-
-        gems[name_and_version] = {
-          'license'     => gem_license,
-          'license_url' => nil,
-          'project_url' => ensure_valid_url(gem_project_url)
-          # TODO: add support for multiple licenses? some gemspecs have dual licensing
-        }
+        gems[gem_name_and_version(spec)] = gem_entry(spec)
       end
       return gems
     end
@@ -103,33 +85,6 @@ module Papers
       end
       packages.empty? ? nil : packages
     end
-
-    def manifest_exists?
-      !!File.exist?(@manifest_path)
-    end
-
-    def build_header
-      [
-        "# Dependency Manifest for the Papers gem",
-        "# Used to test your gems and javascript against license whitelist",
-        "#",
-        "# http://github.com/newrelic/papers\n"
-      ].join("\n")
-    end
-
-    def ensure_valid_url url_string
-      match_url = URI::regexp.match(url_string)
-      if match_url.nil?
-        nil
-      else
-        match_url[0]
-      end
-    end
-
-    def blank? str
-      str.respond_to?(:empty?) ? str.empty? : !str
-    end
-
   end
 
 end

--- a/lib/papers/manifest_generator.rb
+++ b/lib/papers/manifest_generator.rb
@@ -42,49 +42,6 @@ module Papers
       return manifest
     end
 
-    def get_installed_gems
-      gems = {}
-      Bundler.load.specs.each do |spec|
-        gems[gem_name_and_version(spec)] = gem_entry(spec)
-      end
-      return gems
-    end
-
-    def get_installed_javascripts
-      js = {}
-      Javascript.introspected.each do |entry|
-        js[entry] = {
-          'license'     => 'Unknown',
-          'license_url' => nil,
-          'project_url' => nil
-        }
-      end
-      js.empty? ? nil : js
-    end
-
-    def get_installed_bower_components
-      components = {}
-      BowerComponent.full_introspected_entries.each do |entry|
-        components[entry['name']] = {
-          'license' => 'Unknown',
-          'license_url' => nil,
-          'project_url' => ensure_valid_url(entry['homepage'])
-        }
-      end
-      components.empty? ? nil : components
-    end
-
-    def get_installed_npm_packages
-      packages = {}
-      NpmPackage.full_introspected_entries.each do |entry|
-        packages[entry['name']] = {
-          'license' => 'Unknown',
-          'license_url' => nil,
-          'project_url' => nil
-        }
-      end
-      packages.empty? ? nil : packages
-    end
   end
 
 end

--- a/lib/papers/manifest_updater.rb
+++ b/lib/papers/manifest_updater.rb
@@ -100,11 +100,10 @@ module Papers
     end
 
     def manifest_names(result_gems)
-      manifest_names = {}
-      result_gems.each do |(key, _)|
-        manifest_names[name_from_key(key)] = key
+      result_gems.reduce({}) do |hash, (key, _)|
+        hash[name_from_key(key)] = key
+        hash
       end
-      manifest_names
     end
 
     def gemspecs

--- a/lib/papers/manifest_updater.rb
+++ b/lib/papers/manifest_updater.rb
@@ -1,0 +1,85 @@
+require 'bundler'
+require 'yaml'
+require 'fileutils'
+require 'uri'
+
+module Papers
+  class FileMissingError < StandardError
+    def initialize(file)
+      super("Manifest file #{file} missing, can't update.")
+    end
+  end
+
+  class ManifestUpdater < ManifestCommand
+    def update!
+      updated_content = update
+      File.open(@manifest_path, 'w') do |file|
+        file.write(updated_content)
+      end
+    end
+
+    def update
+      raise Papers::FileMissingError.new(@manifest_path) unless manifest_exists?
+
+      original_content = File.read(@manifest_path)
+      result = YAML.load(original_content)
+
+      update_gems(result)
+
+      build_header + YAML.dump(result)
+    end
+
+    def update_gems(result)
+      result_gems = result["gems"]
+
+      manifest_names = manifest_names(result_gems)
+      gemspecs.each do |gemspec|
+        if manifest_gem_key = manifest_names[gemspec.name]
+          update_gem(result_gems, gemspec, manifest_gem_key)
+        else
+          new_gem(result_gems, gemspec)
+        end
+      end
+
+      delete_gems(result_gems, manifest_names)
+    end
+
+    def update_gem(result_gems, gemspec, manifest_gem_key)
+      manifest_gem = result_gems.delete(manifest_gem_key)
+      if gemspec.license != manifest_gem["license"]
+        manifest_gem["license"] = "License Change!"
+      end
+
+      result_gems[gem_name_and_version(gemspec)] = manifest_gem
+    end
+
+    def new_gem(result_gems, gemspec)
+      result_gems[gem_name_and_version(gemspec)] = gem_entry(gemspec)
+    end
+
+    def delete_gems(result_gems, manifest_names)
+      # Find removed gems
+      manifest_names.each do |(gem_name, gem_key)|
+        if gemspecs.none? { |gem| gem.name == gem_name }
+          result_gems.delete(gem_key)
+        end
+      end
+    end
+
+    def name_from_key(key)
+      key.include?("-") ? key.rpartition("-").first : key
+    end
+
+    def manifest_names(result_gems)
+      manifest_names = {}
+      result_gems.each do |(key, _)|
+        manifest_names[name_from_key(key)] = key
+      end
+      manifest_names
+    end
+
+    def gemspecs
+      @gemspecs ||= Bundler.load.specs.dup
+    end
+  end
+end

--- a/lib/papers/manifest_updater.rb
+++ b/lib/papers/manifest_updater.rb
@@ -16,6 +16,8 @@ module Papers
       File.open(@manifest_path, 'w') do |file|
         file.write(updated_content)
       end
+
+      puts "Updated #{@manifest_path}! Run your tests and check your diffs!"
     end
 
     def update
@@ -47,7 +49,11 @@ module Papers
     def update_gem(result_gems, gemspec, manifest_gem_key)
       manifest_gem = result_gems.delete(manifest_gem_key)
       if gemspec.license != manifest_gem["license"]
-        manifest_gem["license"] = "License Change!"
+        new_licenses = gemspec.licenses || []
+        new_licenses << gemspec.license
+        new_licenses.uniq!
+
+        manifest_gem["license"] = "License Change! Was '#{manifest_gem["license"]}', is now #{new_licenses}"
       end
 
       name = gem_name_and_version(gemspec)

--- a/lib/papers/manifest_updater.rb
+++ b/lib/papers/manifest_updater.rb
@@ -50,7 +50,9 @@ module Papers
         manifest_gem["license"] = "License Change!"
       end
 
-      result_gems[gem_name_and_version(gemspec)] = manifest_gem
+      name = gem_name_and_version(gemspec)
+      name = gemspec.name if gemspec.name == manifest_gem_key
+      result_gems[name] = manifest_gem
     end
 
     def new_gem(result_gems, gemspec)

--- a/lib/papers/version.rb
+++ b/lib/papers/version.rb
@@ -1,7 +1,7 @@
 module Papers
   class Version
     MAJOR = 2
-    MINOR = 3
+    MINOR = 4
     PATCH = 0
 
     def self.to_s

--- a/spec/manifest_updater_spec.rb
+++ b/spec/manifest_updater_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe Papers::ManifestUpdater do
+  subject(:updater) { Papers::ManifestUpdater.new(path) }
+
+  let(:path) { "/config/papers_manifest.yml" }
+
+  let(:header) { <<EOS
+# Dependency Manifest for the Papers gem
+# Used to test your gems and javascript against license whitelist
+#
+# http://github.com/newrelic/papers
+---
+EOS
+  }
+
+  let(:original_content) { <<EOS
+#{header.chomp}
+gems:
+  rails-4.2.0:
+    license: MIT
+    license_url: 
+    project_url: https://github.com/rails/rails
+EOS
+  }
+
+  let(:shoes_license) { <<EOS
+  shoes-4.0.0:
+    license: MIT
+    license_url: 
+    project_url: http://shoesrb.com
+EOS
+  }
+
+  before do
+    allow(File).to receive(:read).and_call_original
+    allow(File).to receive(:read).with(path).and_return(original_content)
+
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with(path).and_return(true)
+  end
+
+  it "avoids unnecessary updates" do
+    allow(updater).to receive(:gemspecs).and_return([
+      double(name: 'rails', version: '4.2.0', license: "MIT")
+    ])
+
+    expect(updater.update).to eq(original_content)
+  end
+
+  it "updates version in place" do
+    allow(updater).to receive(:gemspecs).and_return([
+      double(name: 'rails', version: '4.2.7.1', license: "MIT")
+    ])
+
+    expected = original_content.gsub(/rails-4.2.0/, "rails-4.2.7.1")
+    expect(updater.update).to eq(expected)
+  end
+
+  it "adds new gems" do
+    allow(updater).to receive(:gemspecs).and_return([
+      double(name: 'rails', version: '4.2.0', license: "MIT"),
+      double(name: 'shoes', version: '4.0.0', license: "MIT", homepage: "http://shoesrb.com")
+    ])
+
+    expected = original_content + shoes_license
+    expect(updater.update).to eq(expected)
+  end
+
+  it "deletes removed gems" do
+    allow(updater).to receive(:gemspecs).and_return([
+      double(name: 'shoes', version: '4.0.0', license: "MIT", homepage: "http://shoesrb.com")
+    ])
+
+    expected = "#{header}gems:\n#{shoes_license}"
+    expect(updater.update).to eq(expected)
+  end
+
+  it "warns on change to license" do
+    allow(updater).to receive(:gemspecs).and_return([
+      double(name: 'rails', version: '5.0.0', license: "NOT-MIT")
+    ])
+
+    expected = original_content.gsub(/rails-4.2.0/, "rails-5.0.0").
+                                sub(/MIT/, "License Change!")
+    expect(updater.update).to eq(expected)
+  end
+end

--- a/spec/manifest_updater_spec.rb
+++ b/spec/manifest_updater_spec.rb
@@ -21,6 +21,10 @@ gems:
     license: MIT
     license_url: 
     project_url: https://github.com/rails/rails
+  newrelic_rpm:
+    license: New Relic
+    license_url: 
+    project_url: https://github.com/newrelic/rpm
 EOS
   }
 
@@ -42,7 +46,8 @@ EOS
 
   it "avoids unnecessary updates" do
     allow(updater).to receive(:gemspecs).and_return([
-      double(name: 'rails', version: '4.2.0', license: "MIT")
+      double(name: 'rails', version: '4.2.0', license: "MIT"),
+      double(name: 'newrelic_rpm', version: '3.16.2.321', license: "New Relic")
     ])
 
     expect(updater.update).to eq(original_content)
@@ -50,7 +55,8 @@ EOS
 
   it "updates version in place" do
     allow(updater).to receive(:gemspecs).and_return([
-      double(name: 'rails', version: '4.2.7.1', license: "MIT")
+      double(name: 'rails', version: '4.2.7.1', license: "MIT"),
+      double(name: 'newrelic_rpm', version: '3.16.2.321', license: "New Relic")
     ])
 
     expected = original_content.gsub(/rails-4.2.0/, "rails-4.2.7.1")
@@ -60,6 +66,7 @@ EOS
   it "adds new gems" do
     allow(updater).to receive(:gemspecs).and_return([
       double(name: 'rails', version: '4.2.0', license: "MIT"),
+      double(name: 'newrelic_rpm', version: '3.16.2.321', license: "New Relic"),
       double(name: 'shoes', version: '4.0.0', license: "MIT", homepage: "http://shoesrb.com")
     ])
 
@@ -78,7 +85,8 @@ EOS
 
   it "warns on change to license" do
     allow(updater).to receive(:gemspecs).and_return([
-      double(name: 'rails', version: '5.0.0', license: "NOT-MIT")
+      double(name: 'rails', version: '5.0.0', license: "NOT-MIT"),
+      double(name: 'newrelic_rpm', version: '3.16.2.321', license: "New Relic"),
     ])
 
     expected = original_content.gsub(/rails-4.2.0/, "rails-5.0.0").

--- a/spec/manifest_updater_spec.rb
+++ b/spec/manifest_updater_spec.rb
@@ -85,12 +85,12 @@ EOS
 
   it "warns on change to license" do
     allow(updater).to receive(:gemspecs).and_return([
-      double(name: 'rails', version: '5.0.0', license: "NOT-MIT"),
-      double(name: 'newrelic_rpm', version: '3.16.2.321', license: "New Relic"),
+      double(name: 'rails', version: '5.0.0', license: "NOT-MIT", licenses: ["NOT-MIT"]),
+      double(name: 'newrelic_rpm', version: '3.16.2.321', license: "New Relic", licenses: ["New Relic"]),
     ])
 
     expected = original_content.gsub(/rails-4.2.0/, "rails-5.0.0").
-                                sub(/MIT/, "License Change!")
+                                sub(/MIT/, "License Change! Was 'MIT', is now [\"NOT-MIT\"]")
     expect(updater.update).to eq(expected)
   end
 end

--- a/spec/npm_package_spec.rb
+++ b/spec/npm_package_spec.rb
@@ -1,5 +1,3 @@
-require 'bundler/setup'
-require 'rspec'
 require_relative '../lib/papers'
 
 describe 'NpmPackageSpecification' do

--- a/spec/papers_spec.rb
+++ b/spec/papers_spec.rb
@@ -1,6 +1,4 @@
-require 'bundler/setup'
-require 'rspec'
-require_relative '../lib/papers'
+require 'spec_helper'
 
 describe 'Papers' do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'bundler/setup'
+require 'rspec'
+require_relative '../lib/papers'


### PR DESCRIPTION
It's a drag when you `bundle update` a bunch of gems and your papers break. Enter `papers --update`!

This uses similar logic to `papers --generate` does in the first place, and will modify your `papers_manifest.yml` with changed, new, and removed dependencies.

The Ruby support is richest since we have all of Bundler's information to run off of. Javascript, Bower and NPM all just `--generate` a bare list without version information out of the box, so that's how the `--update` works as well.

Highlights of the change:
* New command, `papers --update`
* Extracted `ManifestCommand` class to share functionality between the existing `ManifestGenerator` and new `ManifestUpdater`
* Updating bumps the version on existing gems in the file, and also adds new ones and removes old ones.
* If a gem license doesn't match what's in the current manifest, it inserts an error message into the license to notify you for manual resolution.
  * Note that for cases where the gemspec has a different license string than listed in the manifest (often done because of silly formatting reasons), each update will trigger the warning... might be worth setting your whitelist to include the gem's funky license string to avoid that.
* Thorough specs for the `ManifestUpdater`!

