### PR TITLE
Ignore license mismatch if gemspec is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.1
+* Fix problem where missing licenses from gemspecs overrode hand-authored manifest values.
+
+## 2.4.0
+* Support `papers --update` to bring manifest up to date with current libraries installed.
+
 ## 2.3.0
 * Add `config.ignore_npm_dev_dependencies` option to not apply validation to npm devDepdency modules. This is useful if you don't need to consider packages that aren't use in production.
 

--- a/lib/papers/manifest_updater.rb
+++ b/lib/papers/manifest_updater.rb
@@ -69,7 +69,7 @@ module Papers
 
     def update_gem(result_gems, gemspec, manifest_gem_key)
       manifest_gem = result_gems.delete(manifest_gem_key)
-      if gemspec.license != manifest_gem["license"]
+      if gemspec.license && gemspec.license != manifest_gem["license"]
         new_licenses = gemspec.licenses || []
         new_licenses << gemspec.license
         new_licenses.uniq!

--- a/lib/papers/version.rb
+++ b/lib/papers/version.rb
@@ -2,7 +2,7 @@ module Papers
   class Version
     MAJOR = 2
     MINOR = 4
-    PATCH = 0
+    PATCH = 1
 
     def self.to_s
       [MAJOR, MINOR, PATCH].join('.')

--- a/spec/manifest_updater_spec.rb
+++ b/spec/manifest_updater_spec.rb
@@ -95,6 +95,16 @@ EOS
         sub(/MIT/, "License Change! Was 'MIT', is now [\"NOT-MIT\"]")
       expect(updater.update).to eq(expected)
     end
+
+    it "doesn't touch licenses when missing license in gemspec" do
+      allow(updater).to receive(:gemspecs).and_return([
+        double(name: 'rails', version: '5.0.0', license: nil, licenses: []),
+        double(name: 'newrelic_rpm', version: '3.16.2.321', license: "New Relic", licenses: ["New Relic"]),
+      ])
+
+      expected = original_content.gsub(/rails-4.2.0/, "rails-5.0.0")
+      expect(updater.update).to eq(expected)
+    end
   end
 
   describe "Javascript" do


### PR DESCRIPTION
Fixes #20 by not doing license updates if the gemspec itself doesn't report a license type. Allows the manifest to retain a presumably human authored value for that field during updates.