### PR TITLE
Include info to automatically generate manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ Finished in 0.01043 seconds
 1 examples, 1 failures
 ```
 
+### Generating the manifest from inside your tests
+If you update your gems on a frequent basis, failing to remember to update the Papers manifest can be a time-consuming effort in getting your tests to pass.  If you'd like, you can add this to your test to generate the manifest automatically:
+
+```ruby
+Papers::ManifestUpdater.new.update!
+```
+
+
 ## License
 
 The Papers Gem is licensed under the __MIT License__.  See [MIT-LICENSE](https://github.com/newrelic/papers/blob/master/MIT-LICENSE) for full text.

--- a/README.md
+++ b/README.md
@@ -165,11 +165,13 @@ Finished in 0.01043 seconds
 ```
 
 ### Generating the manifest from inside your tests
-If you update your gems on a frequent basis, failing to remember to update the Papers manifest can be a time-consuming effort in getting your tests to pass.  If you'd like, you can add this to your test to generate the manifest automatically:
+If you update your gems on a frequent basis, failing to remember to update the Papers manifest can be a time-consuming effort in getting your tests to pass.  You can add this to your test to generate the manifest automatically:
 
 ```ruby
 Papers::ManifestUpdater.new.update!
 ```
+
+Note that you should not do this if you manually edit your manifest!
 
 
 ## License


### PR DESCRIPTION
Fixes #29.

So, I just got tired of having my CI fail to pass the build every time we added or updated our Gemfile, because it takes a while for the tests to run, and by the time I learn of the failure, I've already moved on to something else, and I need to go back and fix the manifest.

We don't really care about versions of the gems -- only the licenses -- I didn't see why I needed to verify the gem versions in the manifest matched. 

Are there any pitfalls to doing this?

Or, on the other side of the issue: what benefits does having the manifest bring us in general, and more specifically, what benefit do we get from checking the gem versions?

It seems like as long as the versions match the expectations I set up in my Gemfile, which Bundler takes care of, then I feel good about it, so I'm not sure what is the purpose of having Papers check it.

