### PR TITLE
Include versions with NPM packages

### DIFF
--- a/lib/papers/manifest_command.rb
+++ b/lib/papers/manifest_command.rb
@@ -51,8 +51,8 @@ module Papers
 
     def get_installed_npm_packages
       packages = {}
-      NpmPackage.full_introspected_entries.each do |entry|
-        packages[entry['name']] = {
+      NpmPackage.introspected.each do |entry|
+        packages[entry] = {
           'license' => 'Unknown',
           'license_url' => nil,
           'project_url' => nil


### PR DESCRIPTION
The manifest does not include versions in the package names, but then when checking the manifest against the state of the application, version names are included.  This results in a bunch of "X is in the application but not the manifest" (and the opposite) errors.

This change results in the version being stored the manifest now.