### PR TITLE
strip trailing whitespace before writing manifest

### DIFF
--- a/lib/papers/manifest_updater.rb
+++ b/lib/papers/manifest_updater.rb
@@ -31,7 +31,10 @@ module Papers
       update_javascript(result, "bower_components", get_installed_bower_components)
       update_javascript(result, "npm_packages", get_installed_npm_packages)
 
-      build_header + YAML.dump(result)
+      manifest_content = build_header + YAML.dump(result)
+
+      # strip trailing whitespace, ensure file ends with a newline
+      manifest_content.gsub(/\s*$/, '') + "\n"
     end
 
     def update_gems(result)

--- a/lib/papers/version.rb
+++ b/lib/papers/version.rb
@@ -2,7 +2,7 @@ module Papers
   class Version
     MAJOR = 2
     MINOR = 4
-    PATCH = 2
+    PATCH = 3
 
     def self.to_s
       [MAJOR, MINOR, PATCH].join('.')

--- a/spec/manifest_updater_spec.rb
+++ b/spec/manifest_updater_spec.rb
@@ -28,11 +28,11 @@ EOS
 gems:
   rails-4.2.0:
     license: MIT
-    license_url: 
+    license_url:
     project_url: https://github.com/rails/rails
   newrelic_rpm:
     license: New Relic
-    license_url: 
+    license_url:
     project_url: https://github.com/newrelic/rpm
 EOS
     }
@@ -40,7 +40,7 @@ EOS
     let(:shoes_license) { <<EOS
   shoes-4.0.0:
     license: MIT
-    license_url: 
+    license_url:
     project_url: http://shoesrb.com
 EOS
     }
@@ -117,26 +117,26 @@ javascripts:
     project_url: http://newrelic.com
   app/javascripts/instances/show.js:
     license: Unknown
-    license_url: 
-    project_url: 
+    license_url:
+    project_url:
 bower_components:
   angular:
     license: MIT
-    license_url: 
-    project_url: 
+    license_url:
+    project_url:
   lodash:
     license: Unknown
-    license_url: 
-    project_url: 
+    license_url:
+    project_url:
 npm_packages:
   react:
     license: MIT
-    license_url: 
-    project_url: 
+    license_url:
+    project_url:
   redux:
     license: Unknown
-    license_url: 
-    project_url: 
+    license_url:
+    project_url:
 EOS
     }
 


### PR DESCRIPTION
This fixes `YAML.dump`'s behavior of writing a trailing space character when a field is not present.