### PR TITLE
Handle arrays and improve tests

### DIFF
--- a/lib/papers/manifest_updater.rb
+++ b/lib/papers/manifest_updater.rb
@@ -77,7 +77,8 @@ module Papers
         new_licenses << gemspec.license
         new_licenses.uniq!
 
-        unless manifest_gem['license'].match(/^License Change! Was '.+', is now .+$/)
+        # license key could be an array to_s to protect against that
+        unless manifest_gem['license'].to_s.match(/^License Change! Was '.+', is now .+$/)
           manifest_gem['license'] = "License Change! Was '#{manifest_gem['license']}', is now #{new_licenses}"
         end
       end

--- a/spec/manifest_updater_spec.rb
+++ b/spec/manifest_updater_spec.rb
@@ -55,34 +55,44 @@ EOS
 
     it 'should avoid nesting license change messages' do
       gemspec = double(name: 'foo', version: '1.2.3', license: "some License Change! Was 'New Relic', is now [\"Nonstandard\"]", licenses: [], homepage: 'foo.com')
-      manifest_gem = {
+
+      result_gems = {}
+      manifest_gem_key = 'foo'
+      allow(result_gems).to receive(:delete).with(manifest_gem_key).and_return({
         'name' => 'foo',
         'version' => '1.2.3',
         'license' => "License Change! Was 'New Relic', is now [\"Nonstandard\"]",
         'homepage' => 'foo.com'
-      }
+      })
 
-      result_gems = {}
-      manifest_gem_key = 'foo'
-      allow(result_gems).to receive(:delete).with(manifest_gem_key).and_return(manifest_gem)
       updater.update_gem(result_gems, gemspec, manifest_gem_key)
-      expect(result_gems['foo']).to eq(manifest_gem)
+      expect(result_gems['foo']).to eq({
+        'name' => 'foo',
+        'version' => '1.2.3',
+        'license' => "License Change! Was 'New Relic', is now [\"Nonstandard\"]",
+        'homepage' => 'foo.com'
+      })
     end
 
     it 'should work as normal for non nested changes' do
       gemspec = double(name: 'foo', version: '1.2.3', license: "asdf", licenses: [], homepage: 'foo.com')
-      manifest_gem = {
+
+      result_gems = {}
+      manifest_gem_key = 'foo'
+      allow(result_gems).to receive(:delete).with(manifest_gem_key).and_return({
         'name' => 'foo',
         'version' => '1.2.3',
         'license' => "ldkadfaldfjalkdsfj",
         'homepage' => 'foo.com'
-      }
+      })
 
-      result_gems = {}
-      manifest_gem_key = 'foo'
-      allow(result_gems).to receive(:delete).with(manifest_gem_key).and_return(manifest_gem)
       updater.update_gem(result_gems, gemspec, manifest_gem_key)
-      expect(result_gems['foo']).to eq(manifest_gem)
+      expect(result_gems['foo']).to eq({
+        'name' => 'foo',
+        'version' => '1.2.3',
+        'license' => "License Change! Was 'ldkadfaldfjalkdsfj', is now [\"asdf\"]",
+        'homepage' => 'foo.com'
+      })
     end
 
     it "avoids unnecessary updates" do

--- a/spec/manifest_updater_spec.rb
+++ b/spec/manifest_updater_spec.rb
@@ -95,6 +95,28 @@ EOS
       })
     end
 
+    # We don't want to support it fully, but don't bomb out if we find an array
+    it 'should handle array in manifest' do
+      gemspec = double(name: 'foo', version: '1.2.3', license: "asdf", licenses: ["asdf", "new"], homepage: 'foo.com')
+
+      result_gems = {}
+      manifest_gem_key = 'foo'
+      allow(result_gems).to receive(:delete).with(manifest_gem_key).and_return({
+        'name' => 'foo',
+        'version' => '1.2.3',
+        'license' => ["asdf", "old"],
+        'homepage' => 'foo.com'
+      })
+
+      updater.update_gem(result_gems, gemspec, manifest_gem_key)
+      expect(result_gems['foo']).to eq({
+        'name' => 'foo',
+        'version' => '1.2.3',
+        'license' => "License Change! Was '[\"asdf\", \"old\"]', is now [\"asdf\", \"new\"]",
+        'homepage' => 'foo.com'
+      })
+    end
+
     it "avoids unnecessary updates" do
       allow(updater).to receive(:gemspecs).and_return([
         double(name: 'rails', version: '4.2.0', license: "MIT"),


### PR DESCRIPTION
When testing #35 I found that it was failing on one of our internal apps which had an array in the manifest `license` key instead of a single string. This seems non-standard from what I can tell so not taking lengths to try and "fix" the comparison, but this will at least allow the new update check to not crash.

In looking at that, I noted that the newly added tests were doing an expect against what the mocking effectively made the same object the code altered -- so it wasn't really testing the values. Broke that down so we're using explicitly separate values for the setup vs comparison.

If you could merge this PR with your branch @jwilkinsonnewrelic we'll proceed from that to get it to master.